### PR TITLE
Add example usage and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,31 @@
-# Scorecard
+# Scorecard Core
 
-<a alt="Nx logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="45"></a>
+Scorecard Core provides utilities to gather metrics from GitHub, combine them with
+external API data and calculate an overall score for a repository. It is a small
+collection of Node modules built with Nx.
 
-✨ Your new, shiny [Nx workspace](https://nx.dev) is almost ready ✨.
+## Example usage
 
-[Learn more about this workspace setup and its capabilities](https://nx.dev/nx-api/js?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created. Now, let's get you up to speed!
+A complete example can be found in [examples/basic.ts](examples/basic.ts). After
+installing dependencies you can run it with ts-node:
 
-## Finish your CI setup
-
-[Click here to finish setting up your workspace!](https://cloud.nx.app/connect/sox8rvjXKg)
-
-## Generate a library
-
-```sh
-npx nx g @nx/js:lib packages/pkg1 --publishable --importPath=@my-org/pkg1
+```bash
+npm install
+npx ts-node examples/basic.ts
 ```
 
-## Run tasks
+The script fetches metrics for a repository and prints the calculated scorecard
+result.
 
-To build the library use:
+## Building for npm
 
-```sh
-npx nx build pkg1
+A helper script `build.js` is provided at the repository root. It compiles the
+`@scorecard/scorecard-core` package and prepares the contents of the `dist`
+folder so it can be published to the npm registry.
+
+```bash
+node build.js
 ```
 
-To run any task with Nx use:
-
-```sh
-npx nx <target> <project-name>
-```
-
-These targets are either [inferred automatically](https://nx.dev/concepts/inferred-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or defined in the `project.json` or `package.json` files.
-
-[More about running tasks in the docs &raquo;](https://nx.dev/features/run-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Versioning and releasing
-
-To version and release the library use
-
-```
-npx nx release
-```
-
-Pass `--dry-run` to see what would happen without actually releasing the library.
-
-[Learn more about Nx release &raquo;](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Keep TypeScript project references up to date
-
-Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in `tsconfig.json` files to ensure they remain accurate based on your project dependencies (`import` or `require` statements). This sync is automatically done when running tasks such as `build` or `typecheck`, which require updated references to function correctly.
-
-To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
-
-```sh
-npx nx sync
-```
-
-You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
-
-```sh
-npx nx sync:check
-```
-
-[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
-
-[Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Install Nx Console
-
-Nx Console is an editor extension that enriches your developer experience. It lets you run tasks, generate code, and improves code autocompletion in your IDE. It is available for VSCode and IntelliJ.
-
-[Install Nx Console &raquo;](https://nx.dev/getting-started/editor-setup?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Useful links
-
-Learn more:
-
-- [Learn more about this workspace setup](https://nx.dev/nx-api/js?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Learn about Nx on CI](https://nx.dev/ci/intro/ci-with-nx?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Releasing Packages with Nx release](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [What are Nx plugins?](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-And join the Nx community:
-
-- [Discord](https://go.nx.dev/community)
-- [Follow us on X](https://twitter.com/nxdevtools) or [LinkedIn](https://www.linkedin.com/company/nrwl)
-- [Our Youtube channel](https://www.youtube.com/@nxdevtools)
-- [Our blog](https://nx.dev/blog?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+This will produce a `dist` directory containing the compiled files and a
+`package.json` ready for `npm publish`.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,34 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// Build the scorecard-core package using Nx
+execSync('npx nx build scorecard-core --skip-nx-cache', { stdio: 'inherit' });
+
+const distDir = path.join(__dirname, 'dist');
+const packageDir = path.join(__dirname, 'apps/scorecard-core');
+const builtDir = path.join(packageDir, 'dist');
+
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
+
+// Copy build output
+fs.cpSync(builtDir, distDir, { recursive: true });
+
+// Prepare package.json for publishing
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(packageDir, 'package.json'), 'utf-8'),
+);
+pkg.private = false;
+fs.writeFileSync(
+  path.join(distDir, 'package.json'),
+  JSON.stringify(pkg, null, 2),
+);
+
+// Copy readme
+fs.copyFileSync(
+  path.join(__dirname, 'README.md'),
+  path.join(distDir, 'README.md'),
+);
+
+console.log('Package ready in', distDir);

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,0 +1,31 @@
+import { createScorecard } from '@scorecard/scorecard-core';
+
+async function run() {
+  const ranges = {
+    cycleTime: { min: 0, max: 168 },
+    pickupTime: { min: 0, max: 24 },
+    mergeRate: { min: 0, max: 1 },
+    buildSuccessRate: { min: 0, max: 1 },
+  };
+
+  const weights = {
+    cycleTime: 1,
+    pickupTime: 1,
+    mergeRate: 1,
+    buildSuccessRate: 1,
+  };
+
+  const result = await createScorecard({
+    repo: 'octocat/Hello-World',
+    apiUrl: 'https://example.com/mock',
+    ranges,
+    weights,
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "nx run-many --target=test --all --watch",
     "format": "nx format:write",
     "format:check": "nx format:check",
-    "prettier": "prettier . --write"
+    "prettier": "prettier . --write",
+    "build:package": "node build.js"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
## Summary
- replace default readme with instructions for scorecard-core
- add `examples/basic.ts` demonstrating `createScorecard`
- add `build.js` helper to produce npm-ready package
- expose script `build:package` in `package.json`

## Testing
- `npm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541a93cf0083308dddcd9aaebd2a98