### PR TITLE
Add pluggable engine, git and multi-api support

### DIFF
--- a/apps/scorecard-core/index.d.ts
+++ b/apps/scorecard-core/index.d.ts
@@ -27,6 +27,15 @@ export interface EngineFunctions {
   calculateScore: typeof Score;
 }
 
+export interface RepoSpec {
+  repo: string;
+  token?: string;
+  since?: string;
+  baseUrl?: string;
+  includeLabels?: string[];
+  excludeLabels?: string[];
+}
+
 export interface ScorecardDependencies {
   fetchApiData?: (url: string, options?: FetchApiOptions) => Promise<any>;
   git?: GitFunctions;
@@ -34,6 +43,8 @@ export interface ScorecardDependencies {
 }
 
 export interface ScorecardOptions {
+  repos?: RepoSpec[];
+  /** @deprecated use `repos` */
   repo?: string;
   apis?: ApiSpec[];
   /** @deprecated use `apis` */
@@ -43,6 +54,7 @@ export interface ScorecardOptions {
   staticMetrics?: Record<string, number>;
   ranges: Record<string, { min: number; max: number }>;
   weights: Record<string, number>;
+  /** @deprecated use RepoSpec.token */
   token?: string;
   deps?: ScorecardDependencies;
 }
@@ -53,5 +65,5 @@ export interface ScorecardResult {
   overall: number;
 }
 export function createScorecard(
-  options: ScorecardOptions
+  options: ScorecardOptions,
 ): Promise<ScorecardResult>;

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -24,7 +24,10 @@ async function run() {
   };
 
   const result = await createScorecard({
-    repo: 'octocat/Hello-World',
+    repos: [
+      { repo: 'octocat/Hello-World' },
+      { repo: 'octocat/Spoon-Knife', token: 'MY_TOKEN', since: '2024-01-01' },
+    ],
     apis: [
       { url: 'https://example.com/mock' },
       { url: 'https://example.com/other', options: { params: { q: 'demo' } } },


### PR DESCRIPTION
## Summary
- allow specifying multiple APIs
- inject git functions, scoring engine and API fetcher
- update example to show dependency injection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854547941888330b350966e00983c0f