### PR TITLE
Add pluggable scorecards with repo and API specs

### DIFF
--- a/apps/scorecard-core/index.d.ts
+++ b/apps/scorecard-core/index.d.ts
@@ -1,18 +1,69 @@
-export interface ScorecardOptions {
-  repo: string;
-  apiUrl: string;
-  apiParams?: Record<string, any>;
-  staticMetrics?: Record<string, number>;
-  ranges: Record<string, { min: number; max: number }>;
-  weights: Record<string, number>;
-  token?: string;
+import type { FetchApiOptions } from '@scorecard/scorecard-api';
+import type {
+  collectPullRequests as Collect,
+  calculateMetrics as CalcMetrics,
+  calculateCycleTime as CycleTime,
+  calculateReviewMetrics as ReviewMetrics,
+} from '@scorecard/scorecard-git';
+
+export interface GitFunctions {
+  collectPullRequests: typeof Collect;
+  calculateMetrics: typeof CalcMetrics;
+  calculateCycleTime: typeof CycleTime;
+  calculateReviewMetrics: typeof ReviewMetrics;
 }
+
+export interface ScorecardDependencies {
+  fetchApiData?: (url: string, options?: FetchApiOptions) => Promise<any>;
+  git?: GitFunctions;
+}
+
+export interface GitRepoSpec {
+  key: string;
+  repo: string;
+  provider: string;
+  token?: string;
+  since?: string;
+  baseUrl?: string;
+  includeLabels?: string[];
+  excludeLabels?: string[];
+}
+
+export interface ApiSpec {
+  key: string;
+  url: string;
+  options?: FetchApiOptions;
+  callback?: (data: any) => any;
+}
+
+export interface ScoreEntry {
+  key: string;
+  weight: number;
+  description?: string;
+  score: (data: any) => number;
+}
+
+export interface ScorecardSpec {
+  name: string;
+  description?: string;
+  version?: string;
+  scores: ScoreEntry[];
+}
+
+export interface ScorecardOptions {
+  git?: GitRepoSpec[];
+  apis?: ApiSpec[];
+  scorecard: ScorecardSpec;
+  deps?: ScorecardDependencies;
+}
+
 export interface ScorecardResult {
-  metrics: Record<string, number>;
-  normalized: Record<string, number>;
+  name: string;
+  description?: string;
+  version?: string;
+  results: Record<string, any>;
   scores: Record<string, number>;
   overall: number;
 }
-export function createScorecard(
-  options: ScorecardOptions
-): Promise<ScorecardResult>;
+
+export function createScorecard(options: ScorecardOptions): Promise<ScorecardResult>;

--- a/apps/scorecard-core/src/main.ts
+++ b/apps/scorecard-core/src/main.ts
@@ -1,124 +1,152 @@
 import {
-  collectPullRequests,
-  calculateMetrics,
-  calculateCycleTime,
-  calculateReviewMetrics,
+  collectPullRequests as defaultCollectPullRequests,
+  calculateMetrics as defaultCalculateMetrics,
+  calculateCycleTime as defaultCalculateCycleTime,
+  calculateReviewMetrics as defaultReviewMetrics,
 } from '@scorecard/scorecard-git';
-import { fetchApiData } from '@scorecard/scorecard-api';
-import { normalizeData, calculateScore } from '@scorecard/scorecard-engine';
+import {
+  fetchApiData as defaultFetchApiData,
+  type FetchApiOptions,
+} from '@scorecard/scorecard-api';
+
+export interface GitFunctions {
+  collectPullRequests: typeof defaultCollectPullRequests;
+  calculateMetrics: typeof defaultCalculateMetrics;
+  calculateCycleTime: typeof defaultCalculateCycleTime;
+  calculateReviewMetrics: typeof defaultReviewMetrics;
+}
+
+export interface ScorecardDependencies {
+  fetchApiData?: typeof defaultFetchApiData;
+  git?: GitFunctions;
+}
+
+export interface GitRepoSpec {
+  key: string;
+  repo: string;
+  provider: string;
+  token?: string;
+  since?: string;
+  baseUrl?: string;
+  includeLabels?: string[];
+  excludeLabels?: string[];
+}
+
+export interface ApiSpec {
+  key: string;
+  url: string;
+  options?: FetchApiOptions;
+  callback?: (data: any) => any;
+}
+
+export interface ScoreEntry {
+  key: string;
+  weight: number;
+  description?: string;
+  score: (data: any) => number;
+}
+
+export interface ScorecardSpec {
+  name: string;
+  description?: string;
+  version?: string;
+  scores: ScoreEntry[];
+}
 
 export interface ScorecardOptions {
-  repo: string;
-  apiUrl: string;
-  apiParams?: Record<string, any>;
-  staticMetrics?: Record<string, number>;
-  ranges: Record<string, { min: number; max: number }>;
-  weights: Record<string, number>;
-  token?: string;
+  git?: GitRepoSpec[];
+  apis?: ApiSpec[];
+  scorecard: ScorecardSpec;
+  deps?: ScorecardDependencies;
 }
 
 export interface ScorecardResult {
-  metrics: Record<string, number>;
-  normalized: Record<string, number>;
+  name: string;
+  description?: string;
+  version?: string;
+  results: Record<string, any>;
   scores: Record<string, number>;
   overall: number;
 }
 
-export async function createScorecard(
-  options: ScorecardOptions
-): Promise<ScorecardResult> {
-  const {
-    repo,
-    apiUrl,
-    apiParams,
-    staticMetrics = {},
-    ranges,
-    weights,
-    token,
-  } = options;
+export async function createScorecard(options: ScorecardOptions): Promise<ScorecardResult> {
+  const { git: gitRepos = [], apis = [], scorecard, deps = {} } = options;
 
-  const [owner, repoName] = repo.split('/');
-
-  const prs = await collectPullRequests({
-    owner,
-    repo: repoName,
-    since: new Date(0).toISOString(),
-    auth: token ?? '',
-  }).catch(() => [] as unknown[]);
-
-  const gitMetricsData = calculateMetrics(prs as any);
-
-  const cycleTimes: number[] = [];
-  const pickupTimes: number[] = [];
-  for (const pr of prs as unknown[]) {
-    try {
-      cycleTimes.push(calculateCycleTime(pr as any));
-    } catch {
-      cycleTimes.push(0);
-    }
-    try {
-      pickupTimes.push(calculateReviewMetrics(pr as any));
-    } catch {
-      pickupTimes.push(0);
-    }
-  }
-  const cycleTime =
-    cycleTimes.reduce((a, b) => a + b, 0) / (cycleTimes.length || 1);
-  const pickupTime =
-    pickupTimes.reduce((a, b) => a + b, 0) / (pickupTimes.length || 1);
-
-  const gitMetrics: Record<string, number> = {
-    cycleTime,
-    pickupTime,
-    ...gitMetricsData,
-  } as any;
-
-  const apiMetrics = await fetchApiData(apiUrl, apiParams).catch(
-    () => ({} as Record<string, number>),
-  );
-
-  const numericGitMetrics: Record<string, number> = {};
-  for (const [key, value] of Object.entries(
-    gitMetrics as Record<string, any>
-  )) {
-    if (typeof value === 'number') {
-      numericGitMetrics[key] = value;
-    }
-  }
-
-  const metrics: Record<string, number> = {
-    ...numericGitMetrics,
-    ...apiMetrics,
-    ...staticMetrics,
+  const fetchFn = deps.fetchApiData ?? defaultFetchApiData;
+  const gitFns: GitFunctions = deps.git ?? {
+    collectPullRequests: defaultCollectPullRequests,
+    calculateMetrics: defaultCalculateMetrics,
+    calculateCycleTime: defaultCalculateCycleTime,
+    calculateReviewMetrics: defaultReviewMetrics,
   };
-  const normalized = normalizeData(metrics, ranges);
-  const { scores, overall } = calculateScore(normalized, weights);
 
-  return { metrics, normalized, scores, overall };
+  const results: Record<string, any> = {};
+
+  // Process git repositories
+  for (const spec of gitRepos) {
+    if (spec.provider !== 'github') continue;
+    const [owner, repo] = spec.repo.split('/');
+    const prs = await gitFns
+      .collectPullRequests({
+        owner,
+        repo,
+        since: spec.since ?? new Date(0).toISOString(),
+        auth: spec.token ?? '',
+        baseUrl: spec.baseUrl,
+        includeLabels: spec.includeLabels,
+        excludeLabels: spec.excludeLabels,
+      })
+      .catch(() => [] as unknown[]);
+
+    const metrics = gitFns.calculateMetrics(prs as any);
+    const cycleTimes: number[] = [];
+    const pickupTimes: number[] = [];
+    for (const pr of prs as any[]) {
+      try {
+        cycleTimes.push(gitFns.calculateCycleTime(pr));
+      } catch {
+        cycleTimes.push(0);
+      }
+      try {
+        pickupTimes.push(gitFns.calculateReviewMetrics(pr));
+      } catch {
+        pickupTimes.push(0);
+      }
+    }
+    const cycleTime = cycleTimes.reduce((a, b) => a + b, 0) / (cycleTimes.length || 1);
+    const pickupTime = pickupTimes.reduce((a, b) => a + b, 0) / (pickupTimes.length || 1);
+    results[spec.key] = { cycleTime, pickupTime, ...metrics };
+  }
+
+  // Process APIs
+  for (const api of apis) {
+    const data = await fetchFn(api.url, api.options).catch(() => undefined);
+    results[api.key] = typeof api.callback === 'function' ? api.callback(data) : data;
+  }
+
+  // Calculate scores
+  const scores: Record<string, number> = {};
+  let sum = 0;
+  let totalWeight = 0;
+  for (const entry of scorecard.scores) {
+    const val = entry.score(results[entry.key]);
+    scores[entry.key] = val * entry.weight;
+    sum += scores[entry.key];
+    totalWeight += entry.weight;
+  }
+
+  const overall = totalWeight ? sum / totalWeight : 0;
+
+  return {
+    name: scorecard.name,
+    description: scorecard.description,
+    version: scorecard.version,
+    results,
+    scores,
+    overall,
+  };
 }
 
 if (require.main === module) {
-  (async () => {
-    const ranges = {
-      cycleTime: { min: 0, max: 168 }, // hours
-      pickupTime: { min: 0, max: 24 },
-      mergeRate: { min: 0, max: 1 },
-      buildSuccessRate: { min: 0, max: 1 },
-    };
-
-    const weights = {
-      cycleTime: 1,
-      pickupTime: 1,
-      mergeRate: 1,
-      buildSuccessRate: 1,
-    };
-
-    const result = await createScorecard({
-      repo: 'octocat/Hello-World',
-      apiUrl: 'https://example.com/mock',
-      ranges,
-      weights,
-    });
-    console.log(JSON.stringify(result, null, 2));
-  })();
+  console.log('Run the examples to see usage.');
 }

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,25 +1,104 @@
 import { createScorecard } from '@scorecard/scorecard-core';
+import {
+  scoreMetrics,
+  createRangeNormalizer,
+} from '@scorecard/scorecard-engine';
 
 async function run() {
-  const ranges = {
-    cycleTime: { min: 0, max: 168 },
-    pickupTime: { min: 0, max: 24 },
-    mergeRate: { min: 0, max: 1 },
-    buildSuccessRate: { min: 0, max: 1 },
-  };
-
-  const weights = {
-    cycleTime: 1,
-    pickupTime: 1,
-    mergeRate: 1,
-    buildSuccessRate: 1,
-  };
+  const normalizePickupTime = createRangeNormalizer(
+    [
+      { max: 4, score: 100 },
+      { max: 6, score: 80 },
+      { max: 12, score: 60 },
+    ],
+    40,
+  );
+  const normalizePct = (v: number) => Math.round(v * 100);
 
   const result = await createScorecard({
-    repo: 'octocat/Hello-World',
-    apiUrl: 'https://example.com/mock',
-    ranges,
-    weights,
+    git: [
+      { key: 'hello', repo: 'octocat/Hello-World', provider: 'github' },
+      {
+        key: 'spoon',
+        repo: 'octocat/Spoon-Knife',
+        token: 'MY_TOKEN',
+        since: '2024-01-01',
+        provider: 'github',
+      },
+    ],
+    apis: [
+      {
+        key: 'testing',
+        url: 'https://jsonplaceholder.typicode.com/posts',
+        callback: (data) => data.length,
+      },
+      {
+        key: 'maturity',
+        url: 'https://jsonplaceholder.typicode.com/albums',
+        callback: (data) => data.length,
+      },
+      {
+        key: 'incident',
+        url: 'https://jsonplaceholder.typicode.com/todos',
+        callback: (data) => data.length,
+      },
+      {
+        key: 'change',
+        url: 'https://jsonplaceholder.typicode.com/users',
+        options: { params: { q: 'demo' } },
+        callback: (data) => data.length,
+      },
+    ],
+    scorecard: {
+      name: 'My Scorecard',
+      description: 'A sample scorecard for demonstration purposes',
+      version: '1.0.0',
+      scores: [
+        {
+          key: 'hello',
+          weight: 0.2,
+          description: 'Hello World Repo Score',
+          score: (data) =>
+            scoreMetrics(data, [
+              { weight: 1, metric: 'pickupTime', normalize: normalizePickupTime },
+            ]),
+        },
+        {
+          key: 'spoon',
+          weight: 0.2,
+          description: 'Spoon Knife Repo Score',
+          score: (data) =>
+            scoreMetrics(data, [
+              { weight: 0.5, metric: 'pickupTime', normalize: normalizePickupTime },
+              { weight: 0.5, metric: 'mergeRate', normalize: normalizePct },
+            ]),
+        },
+        {
+          key: 'testing',
+          weight: 0.1,
+          description: 'Testing API Score',
+          score: (data) => data,
+        },
+        {
+          key: 'maturity',
+          weight: 0.3,
+          description: 'Maturity API Score',
+          score: (data) => data,
+        },
+        {
+          key: 'incident',
+          weight: 0.1,
+          description: 'Incident API Score',
+          score: (data) => data,
+        },
+        {
+          key: 'change',
+          weight: 0.1,
+          description: 'Change API Score',
+          score: (data) => data,
+        },
+      ],
+    },
   });
 
   console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
## Summary
- redesign core typings around `git` and `apis` specs
- implement new `createScorecard` supporting score functions per key
- update example to match new API

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854547941888330b350966e00983c0f