### PR TITLE
Update scorecard API

### DIFF
--- a/apps/scorecard-core/index.d.ts
+++ b/apps/scorecard-core/index.d.ts
@@ -15,6 +15,13 @@ export interface ApiSpec {
   options?: FetchApiOptions;
 }
 
+export interface ApiInput {
+  key: string;
+  url: string;
+  options?: FetchApiOptions;
+  callback?: (data: any) => number;
+}
+
 export interface GitFunctions {
   collectPullRequests: typeof Collect;
   calculateMetrics: typeof CalcMetrics;
@@ -36,10 +43,29 @@ export interface RepoSpec {
   excludeLabels?: string[];
 }
 
+export interface GitRepoInput extends RepoSpec {
+  key: string;
+  provider?: string;
+}
+
 export interface ScorecardDependencies {
   fetchApiData?: (url: string, options?: FetchApiOptions) => Promise<any>;
   git?: GitFunctions;
   engine?: EngineFunctions;
+}
+
+export interface ScoreRuleSpec {
+  key: string;
+  weight: number;
+  description?: string;
+  score: (data: any) => number;
+}
+
+export interface ScorecardSpec {
+  name: string;
+  description?: string;
+  version?: string;
+  scores: ScoreRuleSpec[];
 }
 
 export interface ScorecardOptions {
@@ -58,12 +84,32 @@ export interface ScorecardOptions {
   token?: string;
   deps?: ScorecardDependencies;
 }
+
+export interface ScorecardInput {
+  git?: GitRepoInput[];
+  apis?: ApiInput[];
+  scorecard: ScorecardSpec;
+  deps?: ScorecardDependencies;
+}
 export interface ScorecardResult {
   metrics: Record<string, number>;
   normalized: Record<string, number>;
   scores: Record<string, number>;
   overall: number;
 }
-export function createScorecard(
+
+export interface ScorecardOutput {
+  metrics: Record<string, any>;
+  scores: Record<string, number>;
+  overall: number;
+  scorecard: ScorecardSpec;
+}
+
+export { createRangeNormalizer, scoreMetrics } from '@scorecard/scorecard-engine';
+export function createScorecardLegacy(
   options: ScorecardOptions,
 ): Promise<ScorecardResult>;
+
+export function createScorecard(
+  input: ScorecardInput,
+): Promise<ScorecardOutput>;

--- a/apps/scorecard-engine/index.d.ts
+++ b/apps/scorecard-engine/index.d.ts
@@ -24,7 +24,12 @@ export interface ScoreRule<Metrics> {
   normalize?: (value: number, metrics: Metrics) => number;
 }
 
+export interface MetricScore {
+  overall: number;
+  [metric: string]: number;
+}
+
 export function scoreMetrics<Metrics extends Record<string, any>>(
   metrics: Metrics,
   rules: ScoreRule<Metrics>[]
-): number;
+): MetricScore;

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,48 +1,103 @@
-import { createScorecard } from '@scorecard/scorecard-core';
-import { fetchApiData } from '@scorecard/scorecard-api';
-import { normalizeData, calculateScore } from '@scorecard/scorecard-engine';
-import {
-  collectPullRequests,
-  calculateMetrics,
-  calculateCycleTime,
-  calculateReviewMetrics,
-} from '@scorecard/scorecard-git';
+import { createScorecard, scoreMetrics, createRangeNormalizer } from '@scorecard/scorecard-core';
 
 async function run() {
-  const ranges = {
-    cycleTime: { min: 0, max: 168 },
-    pickupTime: { min: 0, max: 24 },
-    mergeRate: { min: 0, max: 1 },
-    buildSuccessRate: { min: 0, max: 1 },
-  };
-
-  const weights = {
-    cycleTime: 1,
-    pickupTime: 1,
-    mergeRate: 1,
-    buildSuccessRate: 1,
-  };
+  const normalizePickupTime = createRangeNormalizer(
+    [
+      { max: 4, score: 100 },
+      { max: 6, score: 80 },
+      { max: 12, score: 60 },
+    ],
+    40,
+  );
+  const normalizePct = (v: number) => Math.round(v * 100);
 
   const result = await createScorecard({
-    repos: [
-      { repo: 'octocat/Hello-World' },
-      { repo: 'octocat/Spoon-Knife', token: 'MY_TOKEN', since: '2024-01-01' },
+    git: [
+      { key: 'hello', repo: 'octocat/Hello-World', provider: 'github' },
+      {
+        key: 'spoon',
+        repo: 'octocat/Spoon-Knife',
+        token: 'MY_TOKEN',
+        since: '2024-01-01',
+        provider: 'github',
+      },
     ],
     apis: [
-      { url: 'https://example.com/mock' },
-      { url: 'https://example.com/other', options: { params: { q: 'demo' } } },
-    ],
-    ranges,
-    weights,
-    deps: {
-      fetchApiData,
-      engine: { normalizeData, calculateScore },
-      git: {
-        collectPullRequests,
-        calculateMetrics,
-        calculateCycleTime,
-        calculateReviewMetrics,
+      {
+        key: 'testing',
+        url: 'https://jsonplaceholder.typicode.com/posts',
+        callback: (data) => data.length,
       },
+      {
+        key: 'maturity',
+        url: 'https://jsonplaceholder.typicode.com/albums',
+        callback: (data) => data.length,
+      },
+      {
+        key: 'incident',
+        url: 'https://jsonplaceholder.typicode.com/todos',
+        callback: (data) => data.length,
+      },
+      {
+        key: 'change',
+        url: 'https://jsonplaceholder.typicode.com/users',
+        options: { params: { q: 'demo' } },
+        callback: (data) => data.length,
+      },
+    ],
+    scorecard: {
+      name: 'My Scorecard',
+      description: 'A sample scorecard for demonstration purposes',
+      version: '1.0.0',
+      scores: [
+        {
+          key: 'hello',
+          weight: 0.2,
+          description: 'Hello World Repo Score',
+          score: (data) => {
+            const score = scoreMetrics(data, [
+              { weight: 1, metric: 'pickupTime', normalize: normalizePickupTime },
+            ]);
+            return score.pickupTime;
+          },
+        },
+        {
+          key: 'spoon',
+          weight: 0.2,
+          description: 'Spoon Knife Repo Score',
+          score: (data) => {
+            const score = scoreMetrics(data, [
+              { weight: 0.5, metric: 'pickupTime', normalize: normalizePickupTime },
+              { weight: 0.5, metric: 'mergeRate', normalize: normalizePct },
+            ]);
+            return score.pickupTime;
+          },
+        },
+        {
+          key: 'testing',
+          weight: 0.1,
+          description: 'Testing API Score',
+          score: (data) => data,
+        },
+        {
+          key: 'maturity',
+          weight: 0.3,
+          description: 'Maturity API Score',
+          score: (data) => data,
+        },
+        {
+          key: 'incident',
+          weight: 0.1,
+          description: 'Incident API Score',
+          score: (data) => data,
+        },
+        {
+          key: 'change',
+          weight: 0.1,
+          description: 'Change API Score',
+          score: (data) => data,
+        },
+      ],
     },
   });
 


### PR DESCRIPTION
## Summary
- redesign scoreMetrics to return per-rule results
- add flexible scorecard API with git and api inputs
- re-export engine helpers
- provide updated example using new API

## Testing
- `npm test` *(fails: nx crashed in container)*

------
https://chatgpt.com/codex/tasks/task_e_6854c00f5bd483308e61bfe0815f8cca