### PR TITLE
Add CLI support with YAML configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ npx ts-node examples/basic.ts
 The script fetches metrics for a repository and prints the calculated scorecard
 result.
 
+## Command line interface
+
+After building the project you can run the scorecard generator directly with a
+YAML configuration file:
+
+```bash
+npm run build:package
+node dist/main.js config.yml
+```
+
+An example configuration might look like:
+
+```yaml
+staticMetrics:
+  cycleTime: 10
+ranges:
+  cycleTime:
+    min: 0
+    max: 20
+weights:
+  cycleTime: 1
+```
+
+The CLI prints the resulting scorecard as JSON.
+
 ## Building for npm
 
 A helper script `build.js` is provided at the repository root. It compiles the

--- a/apps/scorecard-core/package.json
+++ b/apps/scorecard-core/package.json
@@ -74,6 +74,8 @@
     "@scorecard/scorecard-git": "file:../scorecard-git",
     "@scorecard/scorecard-api": "file:../scorecard-api",
     "@scorecard/scorecard-engine": "file:../scorecard-engine",
-    "axios": "^1.6.0"
+    "axios": "^1.6.0",
+    "commander": "^11.1.0",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/apps/scorecard-core/src/cli.spec.ts
+++ b/apps/scorecard-core/src/cli.spec.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+jest.mock('@scorecard/scorecard-git', () => ({
+  collectPullRequests: jest.fn(),
+  calculateMetrics: jest.fn(() => ({})),
+  calculateCycleTime: jest.fn(() => 0),
+  calculateReviewMetrics: jest.fn(() => 0),
+}));
+jest.mock('@scorecard/scorecard-api', () => ({
+  fetchApiData: jest.fn(async () => ({})),
+}));
+jest.mock('@scorecard/scorecard-engine', () => ({
+  normalizeData: jest.fn((v) => v),
+  calculateScore: jest.fn(() => ({ scores: { cycleTime: 0.5 }, overall: 0.5 })),
+}));
+
+import { runCli } from './main';
+
+describe('runCli', () => {
+  it('processes a yaml file and prints results', async () => {
+    const yamlPath = path.join(__dirname, 'test-config.yml');
+    fs.writeFileSync(
+      yamlPath,
+      `staticMetrics:\n  cycleTime: 10\nranges:\n  cycleTime:\n    min: 0\n    max: 20\nweights:\n  cycleTime: 1\n`,
+    );
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await runCli(['node', 'scorecard', yamlPath]);
+      expect(logSpy).toHaveBeenCalled();
+      const output = (logSpy.mock.calls[0]?.[0] as string) || '';
+      const parsed = JSON.parse(output);
+      expect(parsed.overall).toBeCloseTo(0.5);
+    } finally {
+      logSpy.mockRestore();
+      fs.unlinkSync(yamlPath);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "serve:ci": "nx run-many --target=serve --all --configuration=ci",
     "serve:debug": "nx run-many --target=serve --all --configuration=debug",
     "lint": "nx run-many --target=lint --all",
-    "test": "nx run-many --target=test --all --parallel",
+    "test": "CI=1 nx run-many --target=test --all --parallel",
     "test:watch": "nx run-many --target=test --all --watch",
     "format": "nx format:write",
     "format:check": "nx format:check",


### PR DESCRIPTION
## Summary
- add commander/js-yaml deps
- implement `runCli` for scorecard-core
- document CLI usage
- test CLI parsing of YAML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854cef68cc88330a799f2fc63ef860f